### PR TITLE
Enable image uploads on builder

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -318,6 +318,29 @@ Get public page data (no auth required).
 #### GET /pages/render/:slug
 Render public page as HTML (no auth required).
 
+### Upload
+
+#### POST /upload/image
+Upload single image to Cloudinary (requires auth).
+
+**Request:** `multipart/form-data` with field `image`.
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://res.cloudinary.com/.../image.jpg",
+    "public_id": "oxdel/abc123",
+    "width": 800,
+    "height": 600,
+    "format": "jpg",
+    "size": 12345
+  },
+  "message": "Gambar berhasil diupload"
+}
+```
+
 ### Users
 
 #### GET /users/profile


### PR DESCRIPTION
## Summary
- allow uploading image files from TemplateBuilder
- document `/upload/image` endpoint in API docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in backend *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68562a874e30832d95ada16a48e533f2